### PR TITLE
Wrap OpenFisca payload in scenario envelope

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -36,8 +36,15 @@ router.post("/simulate", async (req, res) => {
     // Transformer avec openfiscaVariablesMeta.json
     const payload = buildOpenFiscaPayload(rawJson);
 
+    const scenarioWrapper = payload?.scenarios?.[0];
+    const scenario = scenarioWrapper?.scenario;
+
+    if (!scenario) {
+      throw new Error("Payload OpenFisca invalide: scenario manquant");
+    }
+
     // Ajouter automatiquement les aides à calculer
-    payload.simulateur = {
+    scenario.simulateur = {
       familles: ["rsa", "aide_logement", "af"],
       individus: ["aah"],
       menages: []

--- a/src/variables.js
+++ b/src/variables.js
@@ -119,17 +119,19 @@ export function buildOpenFiscaPayload(rawJson) {
     }
   };
 
-  // Assemble le payload final
+  // Assemble le payload final au format OpenFisca "scenarios"
   const payload = {
-    individus,
-    familles,
-    foyers_fiscaux,
-    menages,
-    simulateur: {
-      familles: ["rsa", "aide_logement", "af"],
-      individus: ["aah"],
-      menages: []
-    }
+    scenarios: [
+      {
+        scenario: {
+          individus,
+          familles,
+          foyers_fiscaux,
+          menages,
+          simulateur: {}
+        }
+      }
+    ]
   };
 
   return payload;


### PR DESCRIPTION
## Summary
- wrap the generated OpenFisca data inside a `scenarios[].scenario` envelope to align with the public API schema
- update the `/simulate` route to populate the `simulateur` section within the nested scenario structure and guard against missing scenarios

## Testing
- node -e "import { buildOpenFiscaPayload } from './src/variables.js'; console.log(JSON.stringify(buildOpenFiscaPayload({ salaire_de_base: 2000, salaire_de_base_conjoint: 1500, age: 35, age_conjoint: 33, nombre_enfants: 1, age_enfant_1: 5 }), null, 2));"

------
https://chatgpt.com/codex/tasks/task_e_68e0e8d034f08320b5601dc86f9c0dac