### PR TITLE
Restore flat OpenFisca payload structure

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -36,15 +36,8 @@ router.post("/simulate", async (req, res) => {
     // Transformer avec openfiscaVariablesMeta.json
     const payload = buildOpenFiscaPayload(rawJson);
 
-    const scenarioWrapper = payload?.scenarios?.[0];
-    const scenario = scenarioWrapper?.scenario;
-
-    if (!scenario) {
-      throw new Error("Payload OpenFisca invalide: scenario manquant");
-    }
-
     // Ajouter automatiquement les aides à calculer
-    scenario.simulateur = {
+    payload.simulateur = {
       familles: ["rsa", "aide_logement", "af"],
       individus: ["aah"],
       menages: []

--- a/src/variables.js
+++ b/src/variables.js
@@ -119,19 +119,12 @@ export function buildOpenFiscaPayload(rawJson) {
     }
   };
 
-  // Assemble le payload final au format OpenFisca "scenarios"
+  // Retourner le payload plat attendu par OpenFisca
   const payload = {
-    scenarios: [
-      {
-        scenario: {
-          individus,
-          familles,
-          foyers_fiscaux,
-          menages,
-          simulateur: {}
-        }
-      }
-    ]
+    individus,
+    familles,
+    foyers_fiscaux,
+    menages
   };
 
   return payload;


### PR DESCRIPTION
## Summary
- return OpenFisca payload builders to emitting flat entity structures
- remove scenario unwrapping in the simulate route and attach the simulateur block to the root payload

## Testing
- curl -s -X POST http://localhost:3001/api/simulate ... *(fails: upstream OpenFisca endpoint unreachable from container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ec1cddb08320a2675f8ed5bd8d33