### PR TITLE
Enforce structured JSON schema and normalize OpenFisca payload input

### DIFF
--- a/src/openai.js
+++ b/src/openai.js
@@ -15,8 +15,29 @@ export async function callOpenAI(userMessage) {
         {
           role: "system",
           content: `
-Tu es un assistant social. 
-Analyse le texte utilisateur et génère uniquement un objet JSON **valide**.
+Tu es un assistant social.
+Analyse le texte utilisateur et génère uniquement un objet JSON **valide** qui respecte strictement le schéma ci-dessous :
+{
+  "salaire_de_base": number | null,
+  "salaire_de_base_conjoint": number | null,
+  "age": number | null,
+  "age_conjoint": number | null,
+  "nombre_enfants": number | null,
+  "enfants": [
+    { "age": number | null }
+  ],
+  "revenu": {
+    "demandeur": { "salaire_de_base": number | null },
+    "conjoint": { "salaire_de_base": number | null }
+  },
+  "situation": {
+    "demandeur": { "age": number | null },
+    "conjoint": { "age": number | null },
+    "enfants": [ { "age": number | null } ]
+  }
+}
+- Chaque champ doit être présent, même si sa valeur est null.
+- Utilise null si l'information n'est pas fournie par l'utilisateur.
 - Ne mets pas de texte explicatif.
 - Ne mets pas de balises Markdown (\`\`\`json).
 - Ne renvoie que du JSON brut (objet { ... }).

--- a/src/variables.js
+++ b/src/variables.js
@@ -99,10 +99,250 @@ function formatPeriodicity(periodicity) {
   return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
 }
 
+function toNumber(value) {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  if (typeof value === "number") {
+    return Number.isNaN(value) ? undefined : value;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.replace(/,/g, ".").trim();
+    if (!normalized) {
+      return undefined;
+    }
+
+    const parsed = Number(normalized);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+
+  return undefined;
+}
+
+function getNestedValue(obj, path) {
+  return path.reduce((acc, key) => {
+    if (acc === undefined || acc === null) {
+      return undefined;
+    }
+    return acc[key];
+  }, obj);
+}
+
+function getValueByPaths(obj, paths) {
+  for (const path of paths) {
+    const value = getNestedValue(obj, path);
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function extractChildAgesFromValue(value) {
+  const ages = [];
+
+  const pushAge = (candidate) => {
+    const num = toNumber(candidate);
+    if (num !== undefined) {
+      ages.push(num);
+    }
+  };
+
+  const inspectItem = (item) => {
+    if (item === undefined || item === null) {
+      return;
+    }
+
+    if (Array.isArray(item)) {
+      item.forEach((child) => inspectItem(child));
+      return;
+    }
+
+    if (typeof item === "number" || typeof item === "string") {
+      pushAge(item);
+      return;
+    }
+
+    if (typeof item === "object") {
+      if (Object.prototype.hasOwnProperty.call(item, "age")) {
+        pushAge(item.age);
+      }
+      if (Object.prototype.hasOwnProperty.call(item, "age_enfant")) {
+        pushAge(item.age_enfant);
+      }
+      if (Object.prototype.hasOwnProperty.call(item, "valeur")) {
+        pushAge(item.valeur);
+      }
+      if (Object.prototype.hasOwnProperty.call(item, "value")) {
+        pushAge(item.value);
+      }
+
+      if (Array.isArray(item.enfants)) {
+        item.enfants.forEach((child) => inspectItem(child));
+      }
+
+      if (Array.isArray(item.children)) {
+        item.children.forEach((child) => inspectItem(child));
+      }
+
+      if (Array.isArray(item.details)) {
+        item.details.forEach((child) => inspectItem(child));
+      }
+
+      Object.entries(item).forEach(([key, child]) => {
+        if (/^enfant_\d+$/.test(key)) {
+          inspectItem(child);
+        }
+      });
+    }
+  };
+
+  inspectItem(value);
+  return ages;
+}
+
+function normalizeUserInput(rawJson = {}) {
+  const source = rawJson && typeof rawJson === "object" ? rawJson : {};
+
+  const salaireDemandeur = toNumber(
+    getValueByPaths(source, [
+      ["salaire_de_base"],
+      ["revenu", "salaire_de_base"],
+      ["revenus", "salaire_de_base"],
+      ["revenu", "demandeur", "salaire_de_base"],
+      ["revenus", "demandeur", "salaire_de_base"],
+      ["situation", "revenu", "demandeur", "salaire_de_base"],
+      ["situation", "demandeur", "revenu", "salaire_de_base"],
+      ["personnes", "demandeur", "revenu", "salaire_de_base"],
+      ["demandeur", "revenu", "salaire_de_base"],
+      ["demandeur", "salaire_de_base"]
+    ])
+  );
+
+  const salaireConjoint = toNumber(
+    getValueByPaths(source, [
+      ["salaire_de_base_conjoint"],
+      ["revenu", "salaire_de_base_conjoint"],
+      ["revenu", "conjoint", "salaire_de_base"],
+      ["revenus", "conjoint", "salaire_de_base"],
+      ["situation", "revenu", "conjoint", "salaire_de_base"],
+      ["situation", "conjoint", "revenu", "salaire_de_base"],
+      ["personnes", "conjoint", "revenu", "salaire_de_base"],
+      ["conjoint", "revenu", "salaire_de_base"],
+      ["conjoint", "salaire_de_base"]
+    ])
+  );
+
+  const ageDemandeur = toNumber(
+    getValueByPaths(source, [
+      ["age"],
+      ["situation", "age"],
+      ["situation", "demandeur", "age"],
+      ["personnes", "demandeur", "age"],
+      ["demandeur", "age"]
+    ])
+  );
+
+  const ageConjoint = toNumber(
+    getValueByPaths(source, [
+      ["age_conjoint"],
+      ["situation", "age_conjoint"],
+      ["situation", "conjoint", "age"],
+      ["personnes", "conjoint", "age"],
+      ["conjoint", "age"]
+    ])
+  );
+
+  const childPaths = [
+    ["enfants"],
+    ["situation", "enfants"],
+    ["situation", "personnes", "enfants"],
+    ["situation", "foyer", "enfants"],
+    ["personnes", "enfants"],
+    ["menage", "enfants"]
+  ];
+
+  const enfantsAges = [];
+  const pushChildAge = (age) => {
+    if (age !== undefined) {
+      enfantsAges.push(age);
+    }
+  };
+
+  const seenChildContainers = new WeakSet();
+  childPaths.forEach((path) => {
+    const value = getNestedValue(source, path);
+    if (value && typeof value === "object") {
+      if (seenChildContainers.has(value)) {
+        return;
+      }
+      seenChildContainers.add(value);
+    }
+    extractChildAgesFromValue(value).forEach(pushChildAge);
+  });
+
+  const indexedChildEntries = Object.entries(source)
+    .filter(([key]) => /^age_enfant_\d+$/.test(key))
+    .sort(
+      ([keyA], [keyB]) =>
+        parseInt(keyA.split("_").pop(), 10) - parseInt(keyB.split("_").pop(), 10)
+    );
+
+  indexedChildEntries.forEach(([, value]) => {
+    const age = toNumber(value);
+    if (age !== undefined) {
+      enfantsAges.push(age);
+    }
+  });
+
+  const nombreEnfantsValeur = toNumber(
+    getValueByPaths(source, [
+      ["nombre_enfants"],
+      ["situation", "nombre_enfants"],
+      ["enfants", "nombre"],
+      ["enfants", "count"],
+      ["situation", "enfants", "nombre"],
+      ["menage", "nombre_enfants"],
+      ["personnes", "nombre_enfants"]
+    ])
+  );
+
+  let nombreEnfants =
+    nombreEnfantsValeur !== undefined ? Math.max(0, Math.round(nombreEnfantsValeur)) : undefined;
+
+  if (nombreEnfants === undefined) {
+    nombreEnfants = enfantsAges.length;
+  }
+
+  if (!Number.isFinite(nombreEnfants)) {
+    nombreEnfants = 0;
+  }
+
+  if (enfantsAges.length > nombreEnfants) {
+    nombreEnfants = enfantsAges.length;
+  }
+
+  while (enfantsAges.length < nombreEnfants) {
+    enfantsAges.push(5);
+  }
+
+  return {
+    salaire_de_base: salaireDemandeur ?? 0,
+    salaire_de_base_conjoint: salaireConjoint ?? 0,
+    age: ageDemandeur ?? 30,
+    age_conjoint: ageConjoint ?? 30,
+    nombre_enfants: nombreEnfants,
+    enfants: enfantsAges
+  };
+}
+
 /**
  * Construit un payload OpenFisca complet à partir d’un rawJson simplifié
  */
 export function buildOpenFiscaPayload(rawJson) {
+  const normalized = normalizeUserInput(rawJson);
   const now = new Date();
   const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
   const currentYear = `${now.getFullYear()}`;
@@ -124,11 +364,12 @@ export function buildOpenFiscaPayload(rawJson) {
   };
 
   // Récupérer les données utilisateur
-  const salaire1 = rawJson.salaire_de_base || 0;
-  const salaire2 = rawJson.salaire_de_base_conjoint || 0;
-  const age1 = rawJson.age || 30;
-  const age2 = rawJson.age_conjoint || 30;
-  const nbEnfants = rawJson.nombre_enfants || 0;
+  const salaire1 = normalized.salaire_de_base;
+  const salaire2 = normalized.salaire_de_base_conjoint;
+  const age1 = normalized.age;
+  const age2 = normalized.age_conjoint;
+  const nbEnfants = normalized.nombre_enfants || 0;
+  const enfantsAges = normalized.enfants || [];
 
   // Construire les individus
   const individus = {
@@ -146,7 +387,7 @@ export function buildOpenFiscaPayload(rawJson) {
 
   // Ajouter les enfants
   for (let i = 1; i <= nbEnfants; i++) {
-    const ageEnfant = rawJson[`age_enfant_${i}`] || 5;
+    const ageEnfant = enfantsAges[i - 1] ?? rawJson?.[`age_enfant_${i}`] ?? 5;
     individus[`enfant_${i}`] = {
       age: createPeriodValues("age", ageEnfant)
     };


### PR DESCRIPTION
## Summary
- update the OpenAI system prompt to demand a JSON object that exposes all fields required by the OpenFisca bridge
- normalize nested OpenAI outputs into flat salary, age, and children data before building the OpenFisca payload
- support multiple child representations when inferring the number of children and their ages

## Testing
- `node --input-type=module <<'NODE' ...` (structure imbriquée)
- `node --input-type=module <<'NODE' ...` (structure mixte)


------
https://chatgpt.com/codex/tasks/task_e_68e0f12be9fc832090760611bf9f3bad