### PR TITLE
Handle AAH inputs separately from salaries

### DIFF
--- a/src/openai.js
+++ b/src/openai.js
@@ -20,12 +20,22 @@ Analyse le texte utilisateur et génère uniquement un objet JSON **valide** qui
 {
   "salaire_de_base": number | null,
   "salaire_de_base_conjoint": number | null,
+  "aah": number | null, // Allocation aux adultes handicapés du demandeur (prestation sociale, distincte d'un salaire)
+  "aah_conjoint": number | null, // Allocation aux adultes handicapés du conjoint (prestation sociale, distincte d'un salaire)
   "age": number | null,
   "age_conjoint": number | null,
   "nombre_enfants": number | null,
   "enfants": [
     { "age": number | null }
   ],
+  "prestations": {
+    "demandeur": {
+      "aah": number | null // Utiliser ce champ pour la prestation AAH du demandeur, ne pas y placer de salaire
+    },
+    "conjoint": {
+      "aah": number | null // Utiliser ce champ pour la prestation AAH du conjoint, ne pas y placer de salaire
+    }
+  },
   "revenu": {
     "demandeur": { "salaire_de_base": number | null },
     "conjoint": { "salaire_de_base": number | null }

--- a/src/variables.js
+++ b/src/variables.js
@@ -235,6 +235,41 @@ function normalizeUserInput(rawJson = {}) {
     ])
   );
 
+  const rawAahDemandeur = getValueByPaths(source, [
+    ["aah"],
+    ["prestations", "aah"],
+    ["prestations", "demandeur", "aah"],
+    ["prestations", "demandeur", "montant_aah"],
+    ["prestations", "demandeur", "allocation_adulte_handicapee"],
+    ["prestations", "demandeur", "allocation_aux_adultes_handicapes"],
+    ["prestations_demandeur", "aah"],
+    ["prestations_demandeur", "allocation_adulte_handicapee"],
+    ["revenu", "demandeur", "aah"],
+    ["revenus", "demandeur", "aah"],
+    ["demandeur", "prestations", "aah"],
+    ["demandeur", "aah"],
+    ["personnes", "demandeur", "aah"]
+  ]);
+
+  const rawAahConjoint = getValueByPaths(source, [
+    ["aah_conjoint"],
+    ["prestations", "aah_conjoint"],
+    ["prestations", "conjoint", "aah"],
+    ["prestations", "conjoint", "montant_aah"],
+    ["prestations", "conjoint", "allocation_adulte_handicapee"],
+    ["prestations", "conjoint", "allocation_aux_adultes_handicapes"],
+    ["prestations_conjoint", "aah"],
+    ["prestations_conjoint", "allocation_adulte_handicapee"],
+    ["revenu", "conjoint", "aah"],
+    ["revenus", "conjoint", "aah"],
+    ["conjoint", "prestations", "aah"],
+    ["conjoint", "aah"],
+    ["personnes", "conjoint", "aah"]
+  ]);
+
+  const aahDemandeur = toNumber(rawAahDemandeur);
+  const aahConjoint = toNumber(rawAahConjoint);
+
   const ageDemandeur = toNumber(
     getValueByPaths(source, [
       ["age"],
@@ -331,6 +366,8 @@ function normalizeUserInput(rawJson = {}) {
   return {
     salaire_de_base: salaireDemandeur ?? 0,
     salaire_de_base_conjoint: salaireConjoint ?? 0,
+    aah: aahDemandeur ?? null,
+    aah_conjoint: aahConjoint ?? null,
     age: ageDemandeur ?? 30,
     age_conjoint: ageConjoint ?? 30,
     nombre_enfants: nombreEnfants,
@@ -366,6 +403,8 @@ export function buildOpenFiscaPayload(rawJson) {
   // Récupérer les données utilisateur
   const salaire1 = normalized.salaire_de_base;
   const salaire2 = normalized.salaire_de_base_conjoint;
+  const aah1 = normalized.aah;
+  const aah2 = normalized.aah_conjoint;
   const age1 = normalized.age;
   const age2 = normalized.age_conjoint;
   const nbEnfants = normalized.nombre_enfants || 0;
@@ -376,12 +415,12 @@ export function buildOpenFiscaPayload(rawJson) {
     individu_1: {
       salaire_de_base: createPeriodValues("salaire_de_base", salaire1),
       age: createPeriodValues("age", age1),
-      aah: createPeriodValues("aah", null)
+      aah: createPeriodValues("aah", aah1 ?? null)
     },
     individu_2: {
       salaire_de_base: createPeriodValues("salaire_de_base", salaire2),
       age: createPeriodValues("age", age2),
-      aah: createPeriodValues("aah", null)
+      aah: createPeriodValues("aah", aah2 ?? null)
     }
   };
 


### PR DESCRIPTION
## Summary
- extend the OpenAI extraction schema with explicit AAH fields and guidance so the model keeps benefits separate from salaries
- parse and normalize AAH amounts (with aliases) independently from wages in the user input
- populate the OpenFisca payload with normalized AAH values while leaving them null when absent

## Testing
- node --input-type=module -e "import { buildOpenFiscaPayload } from './src/variables.js'; const payload = buildOpenFiscaPayload({ aah: 900 }); console.log(JSON.stringify(payload.individus.individu_1, null, 2));"

------
https://chatgpt.com/codex/tasks/task_e_68e0f729f484832094a402cc03ba702a