### PR TITLE
Handle received vs planned benefits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+## Scénario manuel : distinction prestations reçues / à demander
+
+Ce scénario vérifie qu’une prestation mentionnée comme déjà perçue est bien
+injectée dans le payload OpenFisca, alors qu’une prestation simplement envisagée
+reste à `null`.
+
+1. Exécuter la commande suivante :
+
+   ```bash
+   node --input-type=module -e "import { buildOpenFiscaPayload } from './src/variables.js'; const payload = buildOpenFiscaPayload({ prestations_recues: [{ beneficiaire: 'demandeur', nom: 'aah', montant: 860 }], prestations_a_demander: [{ beneficiaire: 'menage', nom: 'rsa' }] }); console.log('AAH individu_1:', payload.individus.individu_1.aah); console.log('RSA famille_1:', payload.familles.famille_1.rsa);"
+   ```
+
+2. Vérifier que la sortie contient un montant pour `AAH individu_1` (la valeur
+   est renseignée car l’aide est déclarée comme reçue) tandis que
+   `RSA famille_1` affiche `{... : null}` : la demande est simplement envisagée
+   et n’est donc pas envoyée à OpenFisca.

--- a/src/openai.js
+++ b/src/openai.js
@@ -28,14 +28,22 @@ Analyse le texte utilisateur et génère uniquement un objet JSON **valide** qui
   "enfants": [
     { "age": number | null }
   ],
-  "prestations": {
-    "demandeur": {
-      "aah": number | null // Utiliser ce champ pour la prestation AAH du demandeur, ne pas y placer de salaire
-    },
-    "conjoint": {
-      "aah": number | null // Utiliser ce champ pour la prestation AAH du conjoint, ne pas y placer de salaire
+  "prestations_recues": [
+    {
+      "beneficiaire": "demandeur" | "conjoint" | "menage", // Qui perçoit déjà l'aide
+      "nom": string, // Exemples : "aah", "rsa", "aide_logement", "af"
+      "montant": number | null, // Montant versé si précisé
+      "commentaire": string | null // Informations complémentaires éventuelles
     }
-  },
+  ],
+  "prestations_a_demander": [
+    {
+      "beneficiaire": "demandeur" | "conjoint" | "menage", // Qui souhaite déposer une demande
+      "nom": string,
+      "montant": number | null,
+      "commentaire": string | null
+    }
+  ],
   "revenu": {
     "demandeur": { "salaire_de_base": number | null },
     "conjoint": { "salaire_de_base": number | null }
@@ -46,6 +54,7 @@ Analyse le texte utilisateur et génère uniquement un objet JSON **valide** qui
     "enfants": [ { "age": number | null } ]
   }
 }
+- Utilise impérativement "prestations_recues" pour les aides déjà perçues et "prestations_a_demander" pour celles seulement envisagées.
 - Chaque champ doit être présent, même si sa valeur est null.
 - Utilise null si l'information n'est pas fournie par l'utilisateur.
 - Ne mets pas de texte explicatif.


### PR DESCRIPTION
## Summary
- extend the OpenAI extraction prompt with explicit `prestations_recues` and `prestations_a_demander` sections
- normalize and map received benefits into OpenFisca payloads while leaving planned aids unset
- document a manual scenario to confirm only received benefits populate OpenFisca variables

## Testing
- node --input-type=module -e "import { buildOpenFiscaPayload } from './src/variables.js'; const payload = buildOpenFiscaPayload({ prestations_recues: [{ beneficiaire: 'demandeur', nom: 'aah', montant: 860 }], prestations_a_demander: [{ beneficiaire: 'menage', nom: 'rsa' }] }); console.log('AAH individu_1:', payload.individus.individu_1.aah); console.log('RSA famille_1:', payload.familles.famille_1.rsa);"


------
https://chatgpt.com/codex/tasks/task_e_68e0f7f7f3108320aa753f408a931e92