### PR TITLE
Limit monthly backfill to resource incomes

### DIFF
--- a/src/variables.js
+++ b/src/variables.js
@@ -871,7 +871,7 @@ export function buildOpenFiscaPayload(rawJson) {
       .map(([name]) => name)
   );
 
-  const createPeriodValues = (variableName, value) => {
+  const wrapValueForPeriodicity = (variableName, value, { backfill = false } = {}) => {
     const periodicity = variablesMeta?.[variableName]?.periodicity;
     const safeValue = value === undefined ? null : value;
 
@@ -881,12 +881,18 @@ export function buildOpenFiscaPayload(rawJson) {
 
     const monthlyValues = { [currentMonth]: safeValue };
 
-    if (periodicity === "month") {
+    if (backfill && (periodicity === "month" || periodicity === undefined)) {
       return backfillPreviousMonths(monthlyValues);
     }
 
     return monthlyValues;
   };
+
+  const createPeriodValues = (variableName, value) =>
+    wrapValueForPeriodicity(variableName, value);
+
+  const createResourcePeriodValues = (variableName, value) =>
+    wrapValueForPeriodicity(variableName, value, { backfill: true });
 
   const prestationsRecues =
     normalized.prestations_recues || createEmptyPrestationsContainer();
@@ -912,14 +918,14 @@ export function buildOpenFiscaPayload(rawJson) {
   // Construire les individus
   const individus = {
     individu_1: {
-      salaire_de_base: createPeriodValues("salaire_de_base", salaire1),
+      salaire_de_base: createResourcePeriodValues("salaire_de_base", salaire1),
       age: createPeriodValues("age", age1),
-      aah: createPeriodValues("aah", aah1 ?? null)
+      aah: createResourcePeriodValues("aah", aah1 ?? null)
     },
     individu_2: {
-      salaire_de_base: createPeriodValues("salaire_de_base", salaire2),
+      salaire_de_base: createResourcePeriodValues("salaire_de_base", salaire2),
       age: createPeriodValues("age", age2),
-      aah: createPeriodValues("aah", aah2 ?? null)
+      aah: createResourcePeriodValues("aah", aah2 ?? null)
     }
   };
 

--- a/test/buildOpenFiscaPayload.test.js
+++ b/test/buildOpenFiscaPayload.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildOpenFiscaPayload } from "../src/variables.js";
+
+function getCurrentMonthKey(now = new Date()) {
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function computeBackfilledMonthKeys(currentMonth, monthsToBackfill = 3) {
+  const [year, month] = currentMonth.split("-").map((part) => Number.parseInt(part, 10));
+  const referenceDate = new Date(Date.UTC(year, month - 1, 1));
+  const keys = [];
+
+  for (let offset = monthsToBackfill; offset >= 1; offset -= 1) {
+    const date = new Date(referenceDate);
+    date.setUTCMonth(date.getUTCMonth() - offset);
+    keys.push(`${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`);
+  }
+
+  keys.push(currentMonth);
+  return keys;
+}
+
+test("monthly non-resource variables stay on current month while resources backfill three months", () => {
+  const payload = buildOpenFiscaPayload({
+    salaire_de_base: 1500,
+    aah: 300,
+    age: 42
+  });
+
+  const individu = payload?.individus?.individu_1;
+  assert.ok(individu, "individu_1 should be present in the payload");
+
+  const currentMonth = getCurrentMonthKey();
+  const expectedMonths = computeBackfilledMonthKeys(currentMonth);
+  const salaireMonths = Object.keys(individu.salaire_de_base).sort();
+  const aahMonths = Object.keys(individu.aah).sort();
+
+  assert.deepEqual(salaireMonths, [...expectedMonths].sort());
+  assert.deepEqual(aahMonths, [...expectedMonths].sort());
+
+  expectedMonths.forEach((monthKey) => {
+    assert.strictEqual(individu.salaire_de_base[monthKey], 1500);
+    assert.strictEqual(individu.aah[monthKey], 300);
+  });
+
+  const ageEntries = Object.entries(individu.age);
+  assert.strictEqual(ageEntries.length, 1);
+  assert.strictEqual(ageEntries[0][0], currentMonth);
+  assert.strictEqual(ageEntries[0][1], 42);
+});


### PR DESCRIPTION
## Summary
- split the monthly period wrapping so that only resource variables use the three-month backfill
- update buildOpenFiscaPayload to use the resource-aware helper for incomes while leaving non-resource fields as single-month
- add a regression test covering the age versus salary backfill behavior

## Testing
- node --test test/buildOpenFiscaPayload.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1224db75c8320a665438e21829c8f