### PR TITLE
Add available benefits extraction helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,27 @@ reste à `null`.
    est renseignée car l’aide est déclarée comme reçue) tandis que
    `RSA famille_1` affiche `{... : null}` : la demande est simplement envisagée
    et n’est donc pas envoyée à OpenFisca.
+
+## Champ `availableBenefits` dans la réponse `/simulate`
+
+L’appel `POST /simulate` renvoie désormais un objet contenant :
+
+```json
+{
+  "payload": { "…" },
+  "result": { "…" },
+  "availableBenefits": [
+    {
+      "id": "rsa",
+      "label": "Revenu de solidarité active",
+      "entity": "famille",
+      "period": "2024-05",
+      "amount": 532.42
+    }
+  ]
+}
+```
+
+`availableBenefits` liste les aides monétaires calculées par OpenFisca pour la
+période en cours (mois ou année selon la variable). Seuls les montants
+strictement positifs sont conservés.

--- a/src/benefits.js
+++ b/src/benefits.js
@@ -1,0 +1,164 @@
+import { getVariablesMeta } from "./variables.js";
+
+const ENTITY_COLLECTION_KEYS = {
+  individu: "individus",
+  famille: "familles",
+  menage: "menages"
+};
+
+const DEFAULT_BENEFIT_VARIABLE_IDS = [
+  "aah",
+  "af",
+  "aide_logement",
+  "ars",
+  "aspa",
+  "asi",
+  "paje_base",
+  "rsa"
+];
+
+function buildBenefitDefinitions(meta) {
+  return DEFAULT_BENEFIT_VARIABLE_IDS.map((candidate) => {
+    const id = typeof candidate === "string" ? candidate : candidate.id;
+    const overrides =
+      candidate && typeof candidate === "object" && candidate.id
+        ? candidate
+        : { id };
+
+    const metaEntry = (meta && meta[id]) || {};
+
+    const entity = overrides.entity || metaEntry.entity;
+    const periodicity = overrides.periodicity || metaEntry.periodicity || "month";
+    const label = overrides.label || metaEntry.description || id;
+
+    return { id, entity, periodicity, label };
+  }).filter((definition) => definition.entity && ENTITY_COLLECTION_KEYS[definition.entity]);
+}
+
+function toFiniteNumber(value) {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.replace(/,/g, ".").trim();
+    if (!normalized) {
+      return undefined;
+    }
+
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  return undefined;
+}
+
+function extractAmountForPeriod(variableValues, periodKey) {
+  if (variableValues === undefined || variableValues === null) {
+    return undefined;
+  }
+
+  if (typeof variableValues === "number" || typeof variableValues === "string") {
+    return toFiniteNumber(variableValues);
+  }
+
+  if (typeof variableValues !== "object") {
+    return undefined;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(variableValues, periodKey)) {
+    const entry = variableValues[periodKey];
+    if (entry && typeof entry === "object" && "value" in entry) {
+      return toFiniteNumber(entry.value);
+    }
+    return toFiniteNumber(entry);
+  }
+
+  if ("value" in variableValues) {
+    return toFiniteNumber(variableValues.value);
+  }
+
+  const periodKeys = Object.keys(variableValues);
+  for (const key of periodKeys) {
+    const entry = variableValues[key];
+    if (entry && typeof entry === "object" && "value" in entry) {
+      const normalized = toFiniteNumber(entry.value);
+      if (normalized !== undefined) {
+        return normalized;
+      }
+    } else {
+      const normalized = toFiniteNumber(entry);
+      if (normalized !== undefined) {
+        return normalized;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function resolvePeriodKey(periodicity, currentMonth, currentYear) {
+  if (periodicity === "year") {
+    return currentYear;
+  }
+  return currentMonth;
+}
+
+export function extractAvailableBenefits(result, options = {}) {
+  if (!result || typeof result !== "object") {
+    return [];
+  }
+
+  const now = options?.now instanceof Date ? options.now : new Date();
+  const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  const currentYear = `${now.getFullYear()}`;
+
+  const meta = getVariablesMeta();
+  const benefitDefinitions = buildBenefitDefinitions(meta);
+
+  const entities = result?.entities || {};
+  const availableBenefits = [];
+
+  for (const benefit of benefitDefinitions) {
+    const containerKey = ENTITY_COLLECTION_KEYS[benefit.entity];
+    const collection = entities?.[containerKey];
+    if (!collection || typeof collection !== "object") {
+      continue;
+    }
+
+    const periodKey = resolvePeriodKey(benefit.periodicity, currentMonth, currentYear);
+
+    let totalAmount = 0;
+    let hasPositiveAmount = false;
+
+    for (const entityValues of Object.values(collection)) {
+      if (!entityValues || typeof entityValues !== "object") {
+        continue;
+      }
+
+      const amount = extractAmountForPeriod(entityValues[benefit.id], periodKey);
+      if (typeof amount === "number" && amount > 0) {
+        totalAmount += amount;
+        hasPositiveAmount = true;
+      }
+    }
+
+    if (hasPositiveAmount && Number.isFinite(totalAmount) && totalAmount > 0) {
+      availableBenefits.push({
+        id: benefit.id,
+        label: benefit.label,
+        entity: benefit.entity,
+        period: periodKey,
+        amount: totalAmount
+      });
+    }
+  }
+
+  return availableBenefits;
+}
+
+export default extractAvailableBenefits;

--- a/src/router.js
+++ b/src/router.js
@@ -2,6 +2,7 @@ import express from "express";
 import { callOpenAI } from "./openai.js";
 import { callOpenFisca } from "./openfisca.js";
 import { buildOpenFiscaPayload } from "./variables.js";
+import extractAvailableBenefits from "./benefits.js";
 
 const router = express.Router();
 
@@ -45,7 +46,9 @@ router.post("/simulate", async (req, res) => {
 
     // Envoi à OpenFisca
     const result = await callOpenFisca(payload);
-    res.json({ payload, result });
+    const availableBenefits = extractAvailableBenefits(result);
+
+    res.json({ payload, result, availableBenefits });
 
   } catch (error) {
     res.status(500).json({ error: error.message });

--- a/src/variables.js
+++ b/src/variables.js
@@ -11,6 +11,10 @@ try {
   console.warn("⚠️ Impossible de charger openfiscaVariablesMeta.json, on utilisera des règles simplifiées.");
 }
 
+export function getVariablesMeta() {
+  return variablesMeta;
+}
+
 function allowNullInAdditionalProperties(schemaNode, insideAdditionalProps = false) {
   if (!schemaNode || typeof schemaNode !== "object") {
     return;

--- a/test/availableBenefits.test.js
+++ b/test/availableBenefits.test.js
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { extractAvailableBenefits } from "../src/benefits.js";
+
+function getCurrentMonthKey(now) {
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+}
+
+test("extractAvailableBenefits agrège les montants mensuels positifs et ignore les zéros", () => {
+  const now = new Date("2024-05-15T12:00:00Z");
+  const currentMonth = getCurrentMonthKey(now);
+
+  const result = {
+    entities: {
+      familles: {
+        famille_1: {
+          rsa: {
+            [currentMonth]: 500,
+            "2024-04": 480
+          },
+          aide_logement: {
+            [currentMonth]: { value: 210.5 }
+          },
+          paje_base: {
+            [currentMonth]: { value: "102.30" }
+          },
+          af: {
+            [currentMonth]: 0
+          }
+        },
+        famille_2: {
+          rsa: {
+            [currentMonth]: { value: 200 }
+          },
+          aide_logement: {
+            [currentMonth]: 0
+          }
+        }
+      },
+      individus: {
+        individu_1: {
+          aah: {
+            [currentMonth]: { value: 800 }
+          },
+          asi: {
+            [currentMonth]: null
+          }
+        },
+        individu_2: {
+          aah: {
+            [currentMonth]: { value: 120 }
+          }
+        }
+      }
+    }
+  };
+
+  const benefits = extractAvailableBenefits(result, { now });
+
+  assert.deepEqual(benefits, [
+    {
+      id: "aah",
+      label: "Allocation adulte handicapé mensualisée",
+      entity: "individu",
+      period: currentMonth,
+      amount: 920
+    },
+    {
+      id: "aide_logement",
+      label: "Aide au logement (tout type)",
+      entity: "famille",
+      period: currentMonth,
+      amount: 210.5
+    },
+    {
+      id: "paje_base",
+      label: "Allocation de base de la PAJE",
+      entity: "famille",
+      period: currentMonth,
+      amount: 102.3
+    },
+    {
+      id: "rsa",
+      label: "Revenu de solidarité active",
+      entity: "famille",
+      period: currentMonth,
+      amount: 700
+    }
+  ]);
+});
+
+test("extractAvailableBenefits gère les variables annuelles", () => {
+  const now = new Date("2024-09-01T08:00:00Z");
+  const currentYear = `${now.getFullYear()}`;
+
+  const result = {
+    entities: {
+      familles: {
+        famille_1: {
+          ars: {
+            [currentYear]: { value: 320 }
+          }
+        },
+        famille_2: {
+          ars: {
+            [currentYear]: 150
+          }
+        }
+      }
+    }
+  };
+
+  const benefits = extractAvailableBenefits(result, { now });
+
+  assert.deepEqual(benefits, [
+    {
+      id: "ars",
+      label: "Allocation de rentrée scolaire",
+      entity: "famille",
+      period: currentYear,
+      amount: 470
+    }
+  ]);
+});


### PR DESCRIPTION
## Summary
- add an `extractAvailableBenefits` helper to aggregate OpenFisca benefit values for the current period
- expose the extracted benefits in the `/simulate` response and document the new field
- cover the helper with unit tests for monthly and yearly variables

## Testing
- node --test test/availableBenefits.test.js
- node --test *(fails: connect ENETUNREACH to api.fr.openfisca.org)*

------
https://chatgpt.com/codex/tasks/task_e_68e37b184e90832093d3faae8a80112a