### PR TITLE
Handle root-level entity collections when extracting available benefits

### DIFF
--- a/src/benefits.js
+++ b/src/benefits.js
@@ -120,7 +120,31 @@ export function extractAvailableBenefits(result, options = {}) {
   const meta = getVariablesMeta();
   const benefitDefinitions = buildBenefitDefinitions(meta);
 
-  const entities = result?.entities || {};
+  const relevantCollectionKeys = Object.values(ENTITY_COLLECTION_KEYS);
+
+  const rootObject = result && typeof result === "object" ? result : {};
+  const entitiesFromResult =
+    rootObject.entities && typeof rootObject.entities === "object" ? rootObject.entities : {};
+
+  const entities = {};
+
+  for (const key of relevantCollectionKeys) {
+    const fromRoot = rootObject[key];
+    const fromEntities = entitiesFromResult[key];
+
+    const normalizedRoot = fromRoot && typeof fromRoot === "object" ? fromRoot : undefined;
+    const normalizedEntities =
+      fromEntities && typeof fromEntities === "object" ? fromEntities : undefined;
+
+    if (!normalizedRoot && !normalizedEntities) {
+      continue;
+    }
+
+    entities[key] = {
+      ...(normalizedRoot || {}),
+      ...(normalizedEntities || {})
+    };
+  }
   const availableBenefits = [];
 
   for (const benefit of benefitDefinitions) {

--- a/test/availableBenefits.test.js
+++ b/test/availableBenefits.test.js
@@ -122,3 +122,76 @@ test("extractAvailableBenefits gère les variables annuelles", () => {
     }
   ]);
 });
+
+test("extractAvailableBenefits prend en compte les collections d'entités à la racine", () => {
+  const now = new Date("2024-03-10T10:00:00Z");
+  const currentMonth = getCurrentMonthKey(now);
+
+  const result = {
+    individus: {
+      individu_1: {
+        aah: {
+          [currentMonth]: { value: 400 }
+        }
+      },
+      individu_2: {
+        aah: {
+          [currentMonth]: 50
+        },
+        af: {
+          [currentMonth]: 0
+        }
+      }
+    },
+    familles: {
+      famille_1: {
+        rsa: {
+          [currentMonth]: { value: 600 }
+        }
+      },
+      famille_2: {
+        rsa: {
+          [currentMonth]: -20
+        }
+      }
+    },
+    autre_propriete: {
+      doit_etre_ignoree: true
+    },
+    entities: {
+      individus: {
+        individu_3: {
+          aah: {
+            [currentMonth]: { value: 20 }
+          }
+        }
+      },
+      familles: {
+        famille_3: {
+          rsa: {
+            [currentMonth]: 50
+          }
+        }
+      }
+    }
+  };
+
+  const benefits = extractAvailableBenefits(result, { now });
+
+  assert.deepEqual(benefits, [
+    {
+      id: "aah",
+      label: "Allocation adulte handicapé mensualisée",
+      entity: "individu",
+      period: currentMonth,
+      amount: 470
+    },
+    {
+      id: "rsa",
+      label: "Revenu de solidarité active",
+      entity: "famille",
+      period: currentMonth,
+      amount: 650
+    }
+  ]);
+});


### PR DESCRIPTION
## Summary
- merge relevant entity collections from both `result.entities` and root-level payload keys before extracting available benefits
- ensure only supported entity collections are considered when building available benefits
- add a regression test covering root-level entity collections and positive amount aggregation

## Testing
- node --test *(fails: OpenFisca API unreachable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e37f4c4ba883208309430511bb5ad2