### PR TITLE
Handle declared benefits in payload

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -46,7 +46,7 @@ router.post("/simulate", async (req, res) => {
 
     // Envoi à OpenFisca
     const result = await callOpenFisca(payload);
-    const availableBenefits = extractAvailableBenefits(result);
+    const availableBenefits = extractAvailableBenefits(result, payload);
 
     res.json({ payload, result, availableBenefits });
 

--- a/test/availableBenefits.test.js
+++ b/test/availableBenefits.test.js
@@ -55,7 +55,7 @@ test("extractAvailableBenefits agrège les montants mensuels positifs et ignore 
     }
   };
 
-  const benefits = extractAvailableBenefits(result, { now });
+  const benefits = extractAvailableBenefits(result, undefined, { now });
 
   assert.deepEqual(benefits, [
     {
@@ -110,7 +110,7 @@ test("extractAvailableBenefits gère les variables annuelles", () => {
     }
   };
 
-  const benefits = extractAvailableBenefits(result, { now });
+  const benefits = extractAvailableBenefits(result, undefined, { now });
 
   assert.deepEqual(benefits, [
     {
@@ -176,7 +176,7 @@ test("extractAvailableBenefits prend en compte les collections d'entités à la 
     }
   };
 
-  const benefits = extractAvailableBenefits(result, { now });
+  const benefits = extractAvailableBenefits(result, undefined, { now });
 
   assert.deepEqual(benefits, [
     {
@@ -194,4 +194,33 @@ test("extractAvailableBenefits prend en compte les collections d'entités à la 
       amount: 650
     }
   ]);
+});
+
+test("extractAvailableBenefits ignore les prestations déjà déclarées dans le payload", () => {
+  const now = new Date("2024-06-01T12:00:00Z");
+  const currentMonth = getCurrentMonthKey(now);
+
+  const payload = {
+    familles: {
+      famille_1: {
+        rsa: {
+          [currentMonth]: 400
+        }
+      }
+    }
+  };
+
+  const result = {
+    familles: {
+      famille_1: {
+        rsa: {
+          [currentMonth]: 400
+        }
+      }
+    }
+  };
+
+  const benefits = extractAvailableBenefits(result, payload, { now });
+
+  assert.deepEqual(benefits, []);
 });


### PR DESCRIPTION
## Summary
- update the available benefit extractor to index positive amounts declared in the payload
- ignore benefits in the OpenFisca result when the payload already declares a positive amount for the same period
- propagate the payload to the extractor and add a regression test covering the scenario

## Testing
- node --test *(fails: scripts/test-openfisca-rsa-backfill.js requires network access to api.fr.openfisca.org)*

------
https://chatgpt.com/codex/tasks/task_e_68e381d9a4e88320961a5781ecf1dc1b