### PR TITLE
Normalize housing status for OpenFisca payload

### DIFF
--- a/src/openai.js
+++ b/src/openai.js
@@ -46,6 +46,19 @@ Analyse le texte utilisateur et génère uniquement un objet JSON **valide** qui
       "commentaire": string | null
     }
   ],
+  "logement": {
+    "statut":
+      "proprietaire" |
+      "primo_accedant" |
+      "locataire" |
+      "locataire_hlm" |
+      "locataire_meuble" |
+      "locataire_foyer" |
+      "heberge_gratuitement" |
+      "sans_domicile" |
+      "autre" | null,
+    "commentaire": string | null // Détails textuels éventuels (ex: "locataire dans le privé")
+  },
   "revenu": {
     "demandeur": { "salaire_de_base": number | null },
     "conjoint": { "salaire_de_base": number | null }
@@ -63,6 +76,8 @@ Analyse le texte utilisateur et génère uniquement un objet JSON **valide** qui
 - Ne mets pas de balises Markdown (\`\`\`json).
 - Ne renvoie que du JSON brut (objet { ... }).
 - Les dates de naissance doivent être exprimées au format ISO AAAA-MM-JJ lorsqu'elles sont connues.
+- Utilise le champ "logement.statut" pour indiquer le statut d'occupation, en choisissant la valeur la plus précise disponible dans la liste proposée (utilise "autre" uniquement si aucune des valeurs ne correspond clairement).
+- Renseigne "logement.statut" à null si l'information n'est pas fournie.
 `
         },
         { role: "user", content: userMessage }

--- a/test/buildOpenFiscaPayload.test.js
+++ b/test/buildOpenFiscaPayload.test.js
@@ -144,3 +144,45 @@ test("birthdates override inconsistent or missing ages", () => {
     "second child age should be derived from birthdate"
   );
 });
+
+test("housing status from user message populates menage payload", () => {
+  const now = new Date();
+  const currentMonth = getCurrentMonthKey(now);
+
+  const ownerPayload = buildOpenFiscaPayload({
+    logement: { statut: "proprietaire" }
+  });
+
+  const hostedPayload = buildOpenFiscaPayload({
+    logement: { statut: "hébergé gratuitement chez mes parents" }
+  });
+
+  const tenantPayload = buildOpenFiscaPayload({
+    logement: { statut: "locataire" }
+  });
+
+  assert.strictEqual(
+    ownerPayload?.menages?.menage_1?.statut_occupation_logement?.[currentMonth],
+    "proprietaire"
+  );
+  assert.strictEqual(
+    hostedPayload?.menages?.menage_1?.statut_occupation_logement?.[currentMonth],
+    "loge_gratuitement"
+  );
+  assert.strictEqual(
+    tenantPayload?.menages?.menage_1?.statut_occupation_logement?.[currentMonth],
+    "locataire_vide"
+  );
+});
+
+test("housing status defaults to non_renseigne when not provided", () => {
+  const now = new Date();
+  const currentMonth = getCurrentMonthKey(now);
+
+  const payload = buildOpenFiscaPayload({});
+
+  assert.strictEqual(
+    payload?.menages?.menage_1?.statut_occupation_logement?.[currentMonth],
+    "non_renseigne"
+  );
+});


### PR DESCRIPTION
## Summary
- extend the OpenAI extraction schema with a structured logement section and guidance for the assistant
- normalize housing status inputs to OpenFisca codes and inject them into the generated payload
- add regression tests ensuring housing status values propagate to the menage payload and default correctly

## Testing
- node --test test/buildOpenFiscaPayload.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3885c04548320a76bf20d2414ffa9