### PR TITLE
Add AI explanation to OpenFisca simulation response

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ L’appel `POST /simulate` renvoie désormais un objet contenant :
       "period": "2024-05",
       "amount": 532.42
     }
-  ]
+  ],
+  "explanation": "Le foyer peut prétendre au RSA pour un montant estimé à 532,42 € par mois…"
 }
 ```
 
 `availableBenefits` liste les aides monétaires calculées par OpenFisca pour la
 période en cours (mois ou année selon la variable). Seuls les montants
-strictement positifs sont conservés.
+strictement positifs sont conservés. Le champ `explanation` fournit un résumé en
+français clair généré automatiquement (ou `null` si la génération échoue).

--- a/src/openai.js
+++ b/src/openai.js
@@ -96,4 +96,50 @@ Analyse le texte utilisateur et génère uniquement un objet JSON **valide** qui
   }
 }
 
+/**
+ * Résume en français un résultat OpenFisca pour l’utilisateur final.
+ * Retourne null si la génération échoue ou si aucun texte n’est produit.
+ */
+export async function describeOpenFiscaResult(result, availableBenefits = []) {
+  const stringify = (data) => {
+    try {
+      return JSON.stringify(data, null, 2);
+    } catch (error) {
+      console.error("Erreur de sérialisation pour describeOpenFiscaResult:", error.message);
+      return "";
+    }
+  };
+
+  try {
+    const response = await client.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: [
+        {
+          role: "system",
+          content:
+            "Tu es un assistant social. Tu aides un conseiller à expliquer en français simple les résultats d'une simulation OpenFisca."
+        },
+        {
+          role: "user",
+          content: `Résume en français clair le résultat OpenFisca ci-dessous pour une personne qui ne connaît pas les termes techniques. Mentionne les aides pertinentes et les montants importants.
+
+Résultat complet:
+${stringify(result)}
+
+Aides disponibles:
+${stringify(availableBenefits)}
+`
+        }
+      ],
+      temperature: 0.7
+    });
+
+    const explanation = response?.choices?.[0]?.message?.content?.trim();
+    return explanation || null;
+  } catch (error) {
+    console.error("Erreur OpenAI (describeOpenFiscaResult):", error.message);
+    return null;
+  }
+}
+
 

--- a/src/router.js
+++ b/src/router.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { callOpenAI } from "./openai.js";
+import { callOpenAI, describeOpenFiscaResult } from "./openai.js";
 import { callOpenFisca } from "./openfisca.js";
 import { buildOpenFiscaPayload } from "./variables.js";
 import extractAvailableBenefits from "./benefits.js";
@@ -48,7 +48,15 @@ router.post("/simulate", async (req, res) => {
     const result = await callOpenFisca(payload);
     const availableBenefits = extractAvailableBenefits(result, payload);
 
-    res.json({ payload, result, availableBenefits });
+    let explanation = null;
+    try {
+      explanation = await describeOpenFiscaResult(result, availableBenefits);
+    } catch (error) {
+      console.error("Impossible de générer l'explication en langage naturel:", error.message);
+      explanation = null;
+    }
+
+    res.json({ payload, result, availableBenefits, explanation });
 
   } catch (error) {
     res.status(500).json({ error: error.message });


### PR DESCRIPTION
## Summary
- add an OpenAI helper that summarizes OpenFisca simulation results in French
- call the helper in the /simulate endpoint and include the generated explanation in the response payload
- document the new explanation field returned by the simulation route

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68e38c6286288320b1f24b5decbc5487