### PR TITLE
Capture first names from AI responses

### DIFF
--- a/src/openai.js
+++ b/src/openai.js
@@ -26,9 +26,11 @@ Analyse le texte utilisateur et génère uniquement un objet JSON **valide** qui
   "age_conjoint": number | null,
   "date_naissance": string | null, // Format ISO AAAA-MM-JJ si connu
   "date_naissance_conjoint": string | null,
+  "prenom_demandeur": string | null,
+  "prenom_conjoint": string | null,
   "nombre_enfants": number | null,
   "enfants": [
-    { "age": number | null, "date_naissance": string | null }
+    { "age": number | null, "date_naissance": string | null, "prenom": string | null }
   ],
   "prestations_recues": [
     {
@@ -64,9 +66,9 @@ Analyse le texte utilisateur et génère uniquement un objet JSON **valide** qui
     "conjoint": { "salaire_de_base": number | null }
   },
   "situation": {
-    "demandeur": { "age": number | null, "date_naissance": string | null },
-    "conjoint": { "age": number | null, "date_naissance": string | null },
-    "enfants": [ { "age": number | null, "date_naissance": string | null } ]
+    "demandeur": { "age": number | null, "date_naissance": string | null, "prenom": string | null },
+    "conjoint": { "age": number | null, "date_naissance": string | null, "prenom": string | null },
+    "enfants": [ { "age": number | null, "date_naissance": string | null, "prenom": string | null } ]
   }
 }
 - Utilise impérativement "prestations_recues" pour les aides déjà perçues et "prestations_a_demander" pour celles seulement envisagées.

--- a/src/router.js
+++ b/src/router.js
@@ -172,6 +172,8 @@ function findChildName(rawJson = {}, index) {
     ["enfants", childNumber - 1, "prenom"],
     ["enfants", childNumber - 1, "first_name"],
     ["enfants", childNumber - 1, "firstname"],
+    ["enfants_details", childNumber - 1, "prenom"],
+    ["enfants_prenoms", childNumber - 1],
     ["situation", "enfants", childNumber - 1],
     ["situation", "enfants", childNumber - 1, "prenom"],
     ["situation", "enfants", childNumber - 1, "first_name"],
@@ -228,7 +230,7 @@ function findChildName(rawJson = {}, index) {
   return undefined;
 }
 
-function buildPersonLabels(rawJson = {}, payload = {}) {
+export function buildPersonLabels(rawJson = {}, payload = {}) {
   const labels = { ...DEFAULT_PERSON_LABELS };
 
   const individu1Name = findRoleName(rawJson, "demandeur");
@@ -295,7 +297,7 @@ function buildTokenVariants(token) {
   return Array.from(variants).filter(Boolean);
 }
 
-function formatExplanation(explanation, personLabels = {}) {
+export function formatExplanation(explanation, personLabels = {}) {
   if (typeof explanation !== "string") {
     return explanation;
   }

--- a/test/personLabels.test.js
+++ b/test/personLabels.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildPersonLabels, formatExplanation } from "../src/router.js";
+
+test("buildPersonLabels utilise les prénoms fournis dans rawJson", () => {
+  const rawJson = {
+    prenom_demandeur: "Alice",
+    prenom_conjoint: "Bob",
+    enfants: [
+      { prenom: "Chloé", age: 6 }
+    ]
+  };
+
+  const payload = {
+    individus: {
+      individu_1: {},
+      individu_2: {},
+      enfant_1: {}
+    }
+  };
+
+  const labels = buildPersonLabels(rawJson, payload);
+
+  assert.strictEqual(labels.individu_1, "Alice");
+  assert.strictEqual(labels.individu_2, "Bob");
+  assert.strictEqual(labels.enfant_1, "Chloé");
+
+  const explanation = "Individu_1 et individu_2 ont aidé enfant_1.";
+  const formatted = formatExplanation(explanation, labels);
+
+  assert.strictEqual(formatted, "Alice et Bob ont aidé Chloé.");
+});


### PR DESCRIPTION
## Summary
- extend the OpenAI prompt schema to request first names for the demandeur, conjoint and children
- normalize incoming payloads to retain first-name data alongside existing age and birthdate processing
- export the person label utilities and add coverage ensuring explanations use provided first names

## Testing
- node --test test

------
https://chatgpt.com/codex/tasks/task_e_68e3917ffdfc8320a851a8c924296532