### PR TITLE
Clarify OpenAI prompt for empty available benefits

### DIFF
--- a/src/openai.js
+++ b/src/openai.js
@@ -141,7 +141,7 @@ export async function describeOpenFiscaResult(
         },
         {
           role: "user",
-          content: `Résume en français clair le résultat OpenFisca ci-dessous pour une personne qui ne connaît pas les termes techniques. Mentionne les aides pertinentes et les montants importants.
+          content: `Résume en français clair le résultat OpenFisca ci-dessous pour une personne qui ne connaît pas les termes techniques. Mentionne les aides pertinentes et les montants importants. Si la liste "availableBenefits" est vide, indique explicitement qu'aucune aide supplémentaire n'est disponible pour cette situation sans laisser penser que les aides déjà perçues disparaissent. Distingue clairement les aides déjà perçues (dans "result") des aides potentielles (dans "availableBenefits").
 
 Résultat complet:
 ${stringify(result)}


### PR DESCRIPTION
## Summary
- clarify the OpenAI prompt so explanations distinguish between benefits already received and potential ones
- instruct the model to explicitly note when no additional benefits are available

## Testing
- OPENAI_API_KEY=dummy node --input-type=module -e "import { describeOpenFiscaResult } from './src/openai.js'; const result = { aides: { dejaPercues: ['allocation'] } }; const explanation = await describeOpenFiscaResult(result, []); console.log('Explanation:', explanation);"

------
https://chatgpt.com/codex/tasks/task_e_68e3ae5e0a74832083c6bb72791a8c9b