### PR TITLE
Clarify OpenFisca result explanation prompt for major aids

### DIFF
--- a/src/openai.js
+++ b/src/openai.js
@@ -141,7 +141,11 @@ export async function describeOpenFiscaResult(
         },
         {
           role: "user",
-          content: `Résume en français clair le résultat OpenFisca ci-dessous pour une personne qui ne connaît pas les termes techniques. Mentionne les aides pertinentes et les montants importants. Si la liste "availableBenefits" est vide, indique explicitement qu'aucune aide supplémentaire n'est disponible pour cette situation sans laisser penser que les aides déjà perçues disparaissent. Distingue clairement les aides déjà perçues (dans "result") des aides potentielles (dans "availableBenefits").
+          content: `Résume en français clair le résultat OpenFisca ci-dessous pour une personne qui ne connaît pas les termes techniques. Mentionne les aides pertinentes et les montants importants.
+- Distingue explicitement les aides déjà perçues (dans "result") des aides potentielles (dans "availableBenefits").
+- Si une aide majeure (RSA, allocations familiales, aide au logement/APL) est absente de "availableBenefits" ou vaut zéro dans "result", explique précisément pourquoi elle n'est pas accessible en t'appuyant sur les données du foyer (revenus y compris AAH, composition familiale, statut de logement, etc.).
+- Appuie chaque explication d'inéligibilité sur les informations chiffrées ou catégorielles du foyer présentes dans les données fournies.
+- Si la liste "availableBenefits" est vide, indique explicitement qu'aucune aide supplémentaire n'est disponible pour cette situation sans laisser penser que les aides déjà perçues disparaissent.
 
 Résultat complet:
 ${stringify(result)}


### PR DESCRIPTION
## Summary
- extend the OpenAI user prompt in describeOpenFiscaResult to require explicit reasons for the absence of major benefits using the household data
- reinforce the distinction between already received benefits and potential benefits, including when none are available

## Testing
- OPENAI_API_KEY=dummytoken node --input-type=module -e "import { describeOpenFiscaResult } from './src/openai.js'; const result = { prestations: { aah: { montant: 971.37 } }, rsa: { montant: 0 }, allocations_familiales: { montant: 0 }, aide_logement: { montant: 0 }, individus: [{ identifiant: 'individu_1', ressources: { aah: 971.37 }, enfants: 0 }], logement: { statut: 'locataire' } }; const availableBenefits = []; describeOpenFiscaResult(result, availableBenefits, { personLabels: { individu_1: 'Alice' } }).then((text)=>{ console.log(text); }).catch((err)=>{ console.error('Generation failed', err.message); process.exit(1);});" (fails: Connection error)


------
https://chatgpt.com/codex/tasks/task_e_68e3b0889018832091f11865a0111ce8