### PR TITLE
Ensure OpenFisca summaries recap existing aids

### DIFF
--- a/src/openai.js
+++ b/src/openai.js
@@ -148,6 +148,8 @@ export async function describeOpenFiscaResult(
 - Lorsque tu abordes les allocations familiales, rappelle qu'elles dépendent du nombre d'enfants à charge et signale explicitement l'absence d'éligibilité lorsqu'il n'y a qu'un seul enfant, sans invoquer les revenus ou le logement pour cette explication.
 - N'émet aucune hypothèse lorsque les données ne permettent pas de justifier une inéligibilité : indique clairement que l'information manque plutôt que de spéculer.
 - Si la liste "availableBenefits" est vide, indique explicitement qu'aucune aide supplémentaire n'est disponible pour cette situation sans laisser penser que les aides déjà perçues disparaissent.
+- Conclus impérativement par un paragraphe de synthèse qui récapitule explicitement toutes les aides effectivement versées avec leurs montants, puis précise clairement s'il n'existe aucune autre aide disponible.
+- Veille à ce que cette synthèse finale mentionne systématiquement chaque prestation déjà versée, y compris l'AAH lorsque c'est le cas, afin d'éviter toute formule laissant entendre qu'aucune aide financière n'est perçue.
 
 Résultat complet:
 ${stringify(result)}


### PR DESCRIPTION
## Summary
- Require the describeOpenFiscaResult prompt to end with a recap of aids actually paid with their amounts and to mention when no further aids are available.
- Instruct the model to always include existing benefits such as the AAH in this final synthesis to avoid implying that no aid is received.

## Testing
- node --test *(fails: OpenFisca API unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b4d4c42c8320ac81ec90864f6ade