### PR TITLE
Add additional benefit calculations to OpenFisca payload

### DIFF
--- a/src/benefits.js
+++ b/src/benefits.js
@@ -14,6 +14,7 @@ const DEFAULT_BENEFIT_VARIABLE_IDS = [
   "aspa",
   "asi",
   "paje_base",
+  "ppa",
   "rsa"
 ];
 


### PR DESCRIPTION
## Summary
- expand benefit name normalisation to recognise prime d'activité, ARS, ASPA, ASI and PAJE variations
- request all tracked benefits (including the prime d'activité) when building the OpenFisca payload
- include the prime d'activité in the default benefits surfaced by the API

## Testing
- node -e "import('./src/variables.js')"
- node -e "import('./src/benefits.js')"


------
https://chatgpt.com/codex/tasks/task_e_68e3ada616e08320a992ff7914ae35ee