### PR TITLE
Add complement familial coverage to benefit tracking

### DIFF
--- a/src/benefits.js
+++ b/src/benefits.js
@@ -13,6 +13,7 @@ const DEFAULT_BENEFIT_VARIABLE_IDS = [
   "ars",
   "aspa",
   "asi",
+  "cf",
   "paje_base",
   "ppa",
   "rsa"

--- a/src/variables.js
+++ b/src/variables.js
@@ -589,6 +589,15 @@ const BENEFIT_NAME_ALIASES = {
     "prime pour l activite",
     "prime pour l'activité",
     "ppa"
+  ],
+  cf: [
+    "cf",
+    "complement familial",
+    "complément familial",
+    "allocation complement familial",
+    "allocation complément familial",
+    "prestation complement familial",
+    "prestation complément familial"
   ]
 };
 
@@ -600,7 +609,8 @@ const TRACKED_BENEFIT_VARIABLES = [
   "aspa",
   "asi",
   "paje_base",
-  "ppa"
+  "ppa",
+  "cf"
 ];
 
 const BENEFICIARY_ALIASES = {


### PR DESCRIPTION
## Summary
- add textual aliases for complément familial and track the benefit in normalized payloads
- include the cf variable in the default benefit list so potential aid extraction covers it

## Testing
- node --input-type=module -e "import { buildOpenFiscaPayload } from './src/variables.js'; const payload = buildOpenFiscaPayload({ nombre_enfants: 3, prestations_recues: [{ beneficiaire: 'menage', nom: 'complément familial', montant: 200 }] }); console.log(JSON.stringify(payload.familles.famille_1.cf, null, 2));"


------
https://chatgpt.com/codex/tasks/task_e_68e3c20de7f48320ab7beead4c9224ab